### PR TITLE
Added support for API pagination

### DIFF
--- a/core/components/getvimeo/elements/snippets/snippet.getvimeo.php
+++ b/core/components/getvimeo/elements/snippets/snippet.getvimeo.php
@@ -40,9 +40,24 @@ $total = 0;
 
 $output = '';
 
+/* See http://developer.vimeo.com/apis/simple */
+$VIMEO_MAX_ITEMS_PER_PAGE=20;
+
 if (!empty($channel)) {
-  $url = unserialize(file_get_contents("http://vimeo.com/api/v2/channel/$channel/videos.php"))
-  or $modx->log(modX::LOG_LEVEL_ERROR, 'getVimeo() - Unable to find Channel: ' . $channel);
+
+  $url = array();
+  $page = 1;
+
+  do {
+     $pagedata = unserialize(file_get_contents("http://vimeo.com/api/v2/channel/$channel/videos.php?page=$page"))
+     or $modx->log(modX::LOG_LEVEL_ERROR, 'getVimeo() - Unable to find Channel: ' . $channel);
+
+     $url= array_merge($url, $pagedata);
+     $page++;
+
+  } while (count($pagedata) == $VIMEO_MAX_ITEMS_PER_PAGE);
+
+
   if (!empty($id)) {
     if (!empty($tpl)) {
       /* ADD REQUESTED VIDEOS TO ARRAY */


### PR DESCRIPTION
Vimeo allows up to 20 items to be returned in each request.
Up to 3 "pages" can be requested, for a total of 60 items.

This patch adds support for requesting more pages if the first
one is full.
